### PR TITLE
Story: [CCLS 2191] Use common auth starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ In order to generate the interface and models a build can be run on the overall 
 ## data-service
 
 the data-service implements the api interface generated in the data-api subproject.
+
+## Common Components
+
+This API uses components from the [LAA CCMS Common Library](https://github.com/ministryofjustice/laa-ccms-spring-boot-common):
+
+- [laa-ccms-spring-boot-plugin](https://github.com/ministryofjustice/laa-ccms-spring-boot-common?tab=readme-ov-file#laa-ccms-spring-boot-gradle-plugin-for-java--spring-boot-projects)
+- [laa-ccms-spring-boot-starter-auth](https://github.com/ministryofjustice/laa-ccms-spring-boot-common/tree/main/laa-ccms-spring-boot-starters/laa-ccms-spring-boot-starter-auth)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.0.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.2' apply false
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.3' apply false
 }
 
 subprojects {

--- a/data-api/build.gradle
+++ b/data-api/build.gradle
@@ -6,9 +6,9 @@ apply plugin: 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin'
 
 dependencies {
 
+    implementation 'io.swagger.core.v3:swagger-annotations:2.2.22'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.data:spring-data-commons'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
@@ -43,7 +43,9 @@ openApiGenerate {
             skipDefaultInterface  : "true",
             useJakartaEe          : "true",
             documentationProvider : "none",
-            serializableModel     : "true"
+            serializableModel     : "true",
+            annotationLibrary     : "swagger2",
+            useSpringBoot3        : "true"
     ]
 }
 

--- a/data-api/open-api-specification.yml
+++ b/data-api/open-api-specification.yml
@@ -27,6 +27,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -56,6 +58,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -85,6 +89,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -143,6 +149,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -172,6 +180,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -265,6 +275,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -298,6 +310,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -326,6 +340,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -354,6 +370,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -387,6 +405,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -420,6 +440,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -453,6 +475,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -486,6 +510,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -519,6 +545,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -552,6 +580,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -590,6 +620,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -628,6 +660,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -666,6 +700,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -699,6 +735,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -734,6 +772,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -776,11 +816,18 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
           description: 'Internal server error'
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Authorization
   schemas:
     baseOffice:
       type: 'object'
@@ -1273,3 +1320,5 @@ components:
         size:
           type: 'integer'
 
+security:
+  - ApiKeyAuth: []

--- a/data-service/build.gradle
+++ b/data-service/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     //Enable access token authentication
-    implementation 'uk.gov.laa.ccms.springboot:laa-ccms-spring-boot-starter-auth:0.0.3-b2f8726-SNAPSHOT'
+    implementation 'uk.gov.laa.ccms.springboot:laa-ccms-spring-boot-starter-auth'
 
     //Enable Swagger UI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'

--- a/data-service/build.gradle
+++ b/data-service/build.gradle
@@ -6,8 +6,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    //Enable access token authentication
+    implementation 'uk.gov.laa.ccms.springboot:laa-ccms-spring-boot-starter-auth:0.0.3-b2f8726-SNAPSHOT'
+
     //Enable Swagger UI
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
     implementation files('lib/ojdbc8.jar')
 

--- a/data-service/src/integrationTest/java/uk/gov/laa/ccms/data/IntegrationTestInterface.java
+++ b/data-service/src/integrationTest/java/uk/gov/laa/ccms/data/IntegrationTestInterface.java
@@ -20,6 +20,7 @@ public interface IntegrationTestInterface {
     registry.add("spring.datasource.username", oracleContainerSingleton.getOracleContainer()::getUsername);
     registry.add("spring.datasource.password", oracleContainerSingleton.getOracleContainer()::getPassword);
 
+    registry.add("laa.ccms.springboot.starter.auth.authentication-header", () -> "Authorization");
     registry.add("laa.ccms.springboot.starter.auth.authorized-clients", () -> "[{\"name\":\"caab-ui\",\"roles\":[\"ALL\"],\"token\":\"d594f93f-e767-4b88-a9e9-2913441edfba\"}]");
     registry.add("laa.ccms.springboot.starter.auth.authorized-roles", () -> "[{\"name\":\"ALL\",\"URIs\":[\"/**\"]}]");
     registry.add("laa.ccms.springboot.starter.auth.unprotected-uris", () -> "[\"\"]");

--- a/data-service/src/integrationTest/java/uk/gov/laa/ccms/data/IntegrationTestInterface.java
+++ b/data-service/src/integrationTest/java/uk/gov/laa/ccms/data/IntegrationTestInterface.java
@@ -19,6 +19,10 @@ public interface IntegrationTestInterface {
     registry.add("spring.datasource.url", oracleContainerSingleton.getOracleContainer()::getJdbcUrl);
     registry.add("spring.datasource.username", oracleContainerSingleton.getOracleContainer()::getUsername);
     registry.add("spring.datasource.password", oracleContainerSingleton.getOracleContainer()::getPassword);
+
+    registry.add("laa.ccms.springboot.starter.auth.authorized-clients", () -> "[{\"name\":\"caab-ui\",\"roles\":[\"ALL\"],\"token\":\"d594f93f-e767-4b88-a9e9-2913441edfba\"}]");
+    registry.add("laa.ccms.springboot.starter.auth.authorized-roles", () -> "[{\"name\":\"ALL\",\"URIs\":[\"/**\"]}]");
+    registry.add("laa.ccms.springboot.starter.auth.unprotected-uris", () -> "[\"\"]");
   }
 }
 

--- a/data-service/src/integrationTest/java/uk/gov/laa/ccms/data/IntegrationTestInterface.java
+++ b/data-service/src/integrationTest/java/uk/gov/laa/ccms/data/IntegrationTestInterface.java
@@ -19,11 +19,6 @@ public interface IntegrationTestInterface {
     registry.add("spring.datasource.url", oracleContainerSingleton.getOracleContainer()::getJdbcUrl);
     registry.add("spring.datasource.username", oracleContainerSingleton.getOracleContainer()::getUsername);
     registry.add("spring.datasource.password", oracleContainerSingleton.getOracleContainer()::getPassword);
-
-    registry.add("laa.ccms.springboot.starter.auth.authentication-header", () -> "Authorization");
-    registry.add("laa.ccms.springboot.starter.auth.authorized-clients", () -> "[{\"name\":\"caab-ui\",\"roles\":[\"ALL\"],\"token\":\"d594f93f-e767-4b88-a9e9-2913441edfba\"}]");
-    registry.add("laa.ccms.springboot.starter.auth.authorized-roles", () -> "[{\"name\":\"ALL\",\"URIs\":[\"/**\"]}]");
-    registry.add("laa.ccms.springboot.starter.auth.unprotected-uris", () -> "[\"\"]");
   }
 }
 

--- a/data-service/src/integrationTest/resources/application.yml
+++ b/data-service/src/integrationTest/resources/application.yml
@@ -1,0 +1,20 @@
+laa.ccms.springboot.starter.auth:
+  authentication-header: "Authorization"
+  authorized-clients: '[
+      {
+          "name": "integration-test-runner",
+          "roles": [
+              "ALL"
+          ],
+          "token": "d594f93f-e767-4b88-a9e9-2913441edfba"
+      }
+  ]'
+  authorized-roles: '[
+      {
+          "name": "ALL",
+          "URIs": [
+              "/**"
+          ]
+      }
+  ]'
+  unprotected-uris: [ "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico", "/open-api-specification.yml"]

--- a/data-service/src/main/resources/application-local.yml
+++ b/data-service/src/main/resources/application-local.yml
@@ -12,3 +12,24 @@ spring:
 
 server:
   port: 8009
+
+laa.ccms.springboot.starter.auth:
+  authentication-header: "Authorization"
+  authorized-clients: '[
+      {
+          "name": "caab-ui",
+          "roles": [
+              "ALL"
+          ],
+          "token": "d594f93f-e767-4b88-a9e9-2913441edfba"
+      }
+  ]'
+  authorized-roles: '[
+      {
+          "name": "ALL",
+          "URIs": [
+              "/**"
+          ]
+      }
+  ]'
+  unprotected-uris: [ "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico", "/open-api-specification.yml"]

--- a/data-service/src/main/resources/application.yml
+++ b/data-service/src/main/resources/application.yml
@@ -10,5 +10,8 @@ spring:
     hibernate:
       ddl-auto: none
 
-
-
+laa.ccms.springboot.starter.auth:
+  authentication-header: "Authorization"
+  authorized-clients: ${AUTHORIZED_CLIENTS}
+  authorized-roles: ${AUTHORIZED_ROLES}
+  unprotected-uris: ${UNPROTECTED_URIS}

--- a/data-service/src/test/resources/application.yml
+++ b/data-service/src/test/resources/application.yml
@@ -6,3 +6,24 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: none
+
+laa.ccms.springboot.starter.auth:
+  authentication-header: "Authorization"
+  authorized-clients: '[
+      {
+          "name": "test-runner",
+          "roles": [
+              "ALL"
+          ],
+          "token": "d594f93f-e767-4b88-a9e9-2913441edfba"
+      }
+  ]'
+  authorized-roles: '[
+      {
+          "name": "ALL",
+          "URIs": [
+              "/**"
+          ]
+      }
+  ]'
+  unprotected-uris: [ "" ]


### PR DESCRIPTION
* Use [common auth starter](https://github.com/ministryofjustice/laa-ccms-spring-boot-common/pull/4)
  * Added application properties to configure auth
* Added 403 Forbidden to endpoints in OpenAPI spec
* Added configuration to handle authentication during testing

**DRAFT**: Common library version needs to be removed (to use version provided by SB plugin) when Auth Starter PR is merged.