### PR TITLE
story(ccls-2346) retrieve declaration text endpoint

### DIFF
--- a/data-api/open-api-specification.yml
+++ b/data-api/open-api-specification.yml
@@ -855,6 +855,40 @@ paths:
           description: 'Not found'
         '500':
           description: 'Internal server error'
+  /lookup/declarations:
+    get:
+      tags:
+        - lookup
+      summary: 'Get a list of declarations'
+      description: get a list of declarations
+      operationId: 'getDeclarations'
+      x-spring-paginated: true
+      parameters:
+        - name: 'type'
+          in: 'query'
+          schema:
+            type: 'string'
+        - name: 'bill-type'
+          in: 'query'
+          schema:
+            type: 'string'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/declarationLookupDetail"
+        '400':
+          description: 'Bad request'
+        '401':
+          description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
+        '404':
+          description: 'Not found'
+        '500':
+          description: 'Internal server error'
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -1371,6 +1405,27 @@ components:
           default: []
           items:
             $ref: "#/components/schemas/assessmentSummaryEntityLookupValueDetail"
+    declarationLookupValueDetail:
+      type: 'object'
+      properties:
+        type:
+          type: 'string'
+        bill_type:
+          type: 'string'
+        number:
+          type: 'string'
+        text:
+          type: 'string'
+    declarationLookupDetail:
+      allOf:
+        - $ref: "#/components/schemas/page"
+      type: 'object'
+      properties:
+        content:
+          type: 'array'
+          default: [ ]
+          items:
+            $ref: "#/components/schemas/declarationLookupValueDetail"
     page:
       type: 'object'
       properties:

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/controller/LookupController.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/controller/LookupController.java
@@ -12,6 +12,7 @@ import uk.gov.laa.ccms.data.model.CaseStatusLookupDetail;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
 import uk.gov.laa.ccms.data.model.MatterTypeLookupDetail;
@@ -67,8 +68,17 @@ public class LookupController implements LookupApi {
    */
   @Override
   public ResponseEntity<CommonLookupDetail> getCountriesLookupValues(
-          String code, Pageable pageable) {
+      final String code,
+      final Pageable pageable) {
     return ResponseEntity.ok(lookupService.getCountryLookupValues(code, pageable));
+  }
+
+  @Override
+  public ResponseEntity<DeclarationLookupDetail> getDeclarations(
+      final String type,
+      final String billType,
+      final Pageable pageable) {
+    return ResponseEntity.ok(lookupService.getDeclarationLookupValues(type, billType, pageable));
   }
 
   /**

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/entity/Declaration.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/entity/Declaration.java
@@ -1,0 +1,67 @@
+package uk.gov.laa.ccms.data.entity;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Entity representing a declaration with type, bill type, and declaration number.
+ * This class is immutable and uses snake_case naming for JSON serialization.
+ */
+@Data
+@Entity
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Table(name = "XXCCMS_DECLARATION_TEXT_V")
+@Immutable
+@IdClass(DeclarationId.class)
+public class Declaration {
+
+  /**
+   * The type of the declaration.
+   */
+  @Id
+  @Column(name = "DECLARATION_TYPE")
+  private String declarationType;
+
+  /**
+   * The type of the bill associated with the declaration.
+   */
+  @Column(name = "BILL_TYPE")
+  //This cannot be included in the id due to the null constraint
+  //if changes are made to this view, we will need to rethink this approach.
+  private String billType;
+
+  /**
+   * The unique number identifying the declaration.
+   */
+  @Id
+  @Column(name = "DECLARATION_NUMBER")
+  private String declarationNumber;
+
+  /**
+   * The text content of the declaration.
+   */
+  @Id
+  @Column(name = "DECLARATION_TEXT")
+  private String declarationText;
+
+
+  /**
+   * Replaces any invalid characters in the declaration text with a single quote.
+   */
+  @PostLoad
+  public void handleDeclarationText() {
+    if (declarationText != null) {
+      declarationText = declarationText.replace('�', '\'');
+    }
+  }
+}

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/entity/DeclarationId.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/entity/DeclarationId.java
@@ -1,0 +1,36 @@
+package uk.gov.laa.ccms.data.entity;
+
+import jakarta.persistence.Column;
+import java.io.Serializable;
+import lombok.Data;
+import org.hibernate.annotations.Immutable;
+
+
+/**
+ * Composite key class for Declaration entity, consisting of declaration type, declaration number
+ * and declaration text. This class is immutable.
+ */
+@Data
+@Immutable
+public class DeclarationId implements Serializable {
+
+  /**
+   * The type of the declaration.
+   */
+  @Column(name = "DECLARATION_TYPE")
+  private String declarationType;
+
+  /**
+   * The unique number identifying the declaration.
+   */
+  @Column(name = "DECLARATION_NUMBER")
+  private String declarationNumber;
+
+  /**
+   * The text for the declaration.
+   */
+  @Column(name = "DECLARATION_TEXT")
+  private String declarationText;
+
+
+}

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/mapper/LookupMapper.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/mapper/LookupMapper.java
@@ -11,6 +11,7 @@ import uk.gov.laa.ccms.data.entity.CaseStatusLookupValue;
 import uk.gov.laa.ccms.data.entity.CategoryOfLawLookupValue;
 import uk.gov.laa.ccms.data.entity.CommonLookupValue;
 import uk.gov.laa.ccms.data.entity.CountryLookupValue;
+import uk.gov.laa.ccms.data.entity.Declaration;
 import uk.gov.laa.ccms.data.entity.EvidenceDocumentTypeLookupValue;
 import uk.gov.laa.ccms.data.entity.LevelOfService;
 import uk.gov.laa.ccms.data.entity.MatterType;
@@ -33,6 +34,8 @@ import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupValueDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupValueDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupValueDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupValueDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
@@ -159,5 +162,14 @@ public interface LookupMapper {
   @Mapping(target = "displayName", source = "opaAttributeDisplayName")
   AssessmentSummaryAttributeLookupValueDetail toAssessmentSummaryAttributeLookupValueDetail(
       AssessmentSummaryAttribute assessmentSummaryAttribute);
+
+  DeclarationLookupDetail toDeclarationLookupDetail(
+      Page<Declaration> declarations);
+
+  @Mapping(target = "type", source = "declarationType")
+  @Mapping(target = "number", source = "declarationNumber")
+  @Mapping(target = "text", source = "declarationText")
+  DeclarationLookupValueDetail toDeclarationLookupValueDetail(
+      Declaration declaration);
 
 }

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/repository/DeclarationRepository.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/repository/DeclarationRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.laa.ccms.data.repository;
+
+import uk.gov.laa.ccms.data.entity.Declaration;
+import uk.gov.laa.ccms.data.entity.DeclarationId;
+
+/**
+ * Repository interface for performing read-only operations on Declaration entities.
+ */
+public interface DeclarationRepository extends ReadOnlyRepository<Declaration, DeclarationId> {
+}

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/service/LookupService.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/service/LookupService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,6 +20,7 @@ import uk.gov.laa.ccms.data.entity.CaseStatusLookupValue;
 import uk.gov.laa.ccms.data.entity.CategoryOfLawLookupValue;
 import uk.gov.laa.ccms.data.entity.CommonLookupValue;
 import uk.gov.laa.ccms.data.entity.CountryLookupValue;
+import uk.gov.laa.ccms.data.entity.Declaration;
 import uk.gov.laa.ccms.data.entity.EvidenceDocumentTypeLookupValue;
 import uk.gov.laa.ccms.data.entity.EvidenceDocumentTypeLookupValueId;
 import uk.gov.laa.ccms.data.entity.LevelOfService;
@@ -40,6 +42,7 @@ import uk.gov.laa.ccms.data.model.CaseStatusLookupDetail;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
 import uk.gov.laa.ccms.data.model.MatterTypeLookupDetail;
@@ -53,6 +56,7 @@ import uk.gov.laa.ccms.data.repository.CaseStatusLookupValueRepository;
 import uk.gov.laa.ccms.data.repository.CategoryOfLawLookupValueRepository;
 import uk.gov.laa.ccms.data.repository.CommonLookupValueRepository;
 import uk.gov.laa.ccms.data.repository.CountryLookupValueRepository;
+import uk.gov.laa.ccms.data.repository.DeclarationRepository;
 import uk.gov.laa.ccms.data.repository.EvidenceDocumentTypeLookupValueRepository;
 import uk.gov.laa.ccms.data.repository.LevelOfServiceRepository;
 import uk.gov.laa.ccms.data.repository.MatterTypeRepository;
@@ -103,6 +107,8 @@ public class LookupService extends AbstractEbsDataService {
   private final EvidenceDocumentTypeLookupValueRepository evidenceDocumentTypeLookupValueRepository;
 
   private final AssessmentSummaryAttributesRepository assessmentSummaryAttributesRepository;
+
+  private final DeclarationRepository declarationRepository;
 
 
   /**
@@ -416,6 +422,29 @@ public class LookupService extends AbstractEbsDataService {
 
     return lookupMapper.toEvidenceDocumentTypeLookupDetail(
         evidenceDocumentTypeLookupValueRepository.findAll(Example.of(example), pageable));
+  }
+
+  /**
+   * Retrieves declaration lookup values based on the specified declaration type and bill type.
+   *
+   * @param declarationType the type of declaration to filter by
+   * @param billType the type of bill to filter by
+   * @param pageable pagination details
+   * @return the declaration lookup details
+   */
+  public DeclarationLookupDetail getDeclarationLookupValues(
+      final String declarationType,
+      final String billType,
+      final Pageable pageable
+  ) {
+    Declaration example = new Declaration();
+    example.setDeclarationType(declarationType);
+    example.setBillType(billType);
+
+    Page<Declaration> declarations = declarationRepository.findAll(Example.of(example), pageable);
+
+    return lookupMapper.toDeclarationLookupDetail(
+        declarations);
   }
 
   /**

--- a/data-service/src/test/java/uk/gov/laa/ccms/data/controller/LookupControllerTest.java
+++ b/data-service/src/test/java/uk/gov/laa/ccms/data/controller/LookupControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,6 +29,7 @@ import uk.gov.laa.ccms.data.model.CaseStatusLookupDetail;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
 import uk.gov.laa.ccms.data.model.MatterTypeLookupDetail;
@@ -329,5 +331,27 @@ class LookupControllerTest {
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(expectedResponse, responseEntity.getBody());
     }
+
+    @Test
+    @DisplayName("getDeclarations returns DeclarationLookupDetail")
+    void getDeclarations_returnsDeclarationLookupDetail() throws Exception {
+        String type = "type1";
+        String billType = "bill1";
+        Pageable pageable = Pageable.ofSize(20);
+
+        DeclarationLookupDetail expectedResponse = new DeclarationLookupDetail();
+
+        when(lookupService.getDeclarationLookupValues(type, billType, pageable))
+            .thenReturn(expectedResponse);
+
+        mockMvc.perform(get("/lookup/declarations")
+                .param("type", type)
+                .param("bill-type", billType))
+            .andDo(print())
+            .andExpect(status().isOk());
+
+        verify(lookupService).getDeclarationLookupValues(type, billType, pageable);
+    }
+
 
 }

--- a/data-service/src/test/java/uk/gov/laa/ccms/data/mapper/LookupMapperImplTest.java
+++ b/data-service/src/test/java/uk/gov/laa/ccms/data/mapper/LookupMapperImplTest.java
@@ -9,6 +9,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,6 +23,7 @@ import uk.gov.laa.ccms.data.entity.CaseStatusLookupValue;
 import uk.gov.laa.ccms.data.entity.CategoryOfLawLookupValue;
 import uk.gov.laa.ccms.data.entity.CommonLookupValue;
 import uk.gov.laa.ccms.data.entity.CountryLookupValue;
+import uk.gov.laa.ccms.data.entity.Declaration;
 import uk.gov.laa.ccms.data.entity.EvidenceDocumentTypeLookupValue;
 import uk.gov.laa.ccms.data.entity.EvidenceDocumentTypeLookupValueId;
 import uk.gov.laa.ccms.data.entity.LevelOfService;
@@ -50,6 +52,8 @@ import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupValueDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupValueDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupValueDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupValueDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
@@ -1001,8 +1005,50 @@ class LookupMapperImplTest {
         return detail;
     }
 
+    @Test
+    @DisplayName("toDeclarationLookupDetail returns correct detail for a given page of declarations")
+    void toDeclarationLookupDetail_returnsCorrectDetail() {
+        Declaration declaration1 = new Declaration();
+        declaration1.setDeclarationType("type1");
+        declaration1.setBillType("billType1");
 
+        Declaration declaration2 = new Declaration();
+        declaration2.setDeclarationType("type2");
+        declaration2.setBillType("billType2");
 
+        Page<Declaration> page = new PageImpl<>(List.of(declaration1, declaration2));
 
+        DeclarationLookupDetail expected = new DeclarationLookupDetail();
+        expected.setTotalPages(page.getTotalPages());
+        expected.setTotalElements((int) page.getTotalElements());
+        expected.setNumber(page.getNumber());
+        expected.setSize(page.getSize());
+        expected.setContent(List.of(
+            mapper.toDeclarationLookupValueDetail(declaration1),
+            mapper.toDeclarationLookupValueDetail(declaration2)
+        ));
+
+        DeclarationLookupDetail actual = mapper.toDeclarationLookupDetail(page);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("toDeclarationLookupValueDetail returns correct detail for a given declaration")
+    void toDeclarationLookupValueDetail_returnsCorrectDetail() {
+        Declaration declaration = new Declaration();
+        declaration.setDeclarationType("type");
+        declaration.setDeclarationNumber("123");
+        declaration.setDeclarationText("Declaration text");
+
+        DeclarationLookupValueDetail expected = new DeclarationLookupValueDetail();
+        expected.setType(declaration.getDeclarationType());
+        expected.setNumber(declaration.getDeclarationNumber());
+        expected.setText(declaration.getDeclarationText());
+
+        DeclarationLookupValueDetail actual = mapper.toDeclarationLookupValueDetail(declaration);
+
+        assertEquals(expected, actual);
+    }
 
 }

--- a/data-service/src/test/java/uk/gov/laa/ccms/data/service/LookupServiceTest.java
+++ b/data-service/src/test/java/uk/gov/laa/ccms/data/service/LookupServiceTest.java
@@ -10,6 +10,7 @@ import jakarta.persistence.criteria.Root;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,6 +32,7 @@ import uk.gov.laa.ccms.data.entity.CaseStatusLookupValue;
 import uk.gov.laa.ccms.data.entity.CategoryOfLawLookupValue;
 import uk.gov.laa.ccms.data.entity.CommonLookupValue;
 import uk.gov.laa.ccms.data.entity.CountryLookupValue;
+import uk.gov.laa.ccms.data.entity.Declaration;
 import uk.gov.laa.ccms.data.entity.EvidenceDocumentTypeLookupValue;
 import uk.gov.laa.ccms.data.entity.EvidenceDocumentTypeLookupValueId;
 import uk.gov.laa.ccms.data.entity.LevelOfService;
@@ -52,6 +54,7 @@ import uk.gov.laa.ccms.data.model.CaseStatusLookupDetail;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
 import uk.gov.laa.ccms.data.model.MatterTypeLookupDetail;
@@ -65,6 +68,7 @@ import uk.gov.laa.ccms.data.repository.CaseStatusLookupValueRepository;
 import uk.gov.laa.ccms.data.repository.CategoryOfLawLookupValueRepository;
 import uk.gov.laa.ccms.data.repository.CommonLookupValueRepository;
 import uk.gov.laa.ccms.data.repository.CountryLookupValueRepository;
+import uk.gov.laa.ccms.data.repository.DeclarationRepository;
 import uk.gov.laa.ccms.data.repository.EvidenceDocumentTypeLookupValueRepository;
 import uk.gov.laa.ccms.data.repository.LevelOfServiceRepository;
 import uk.gov.laa.ccms.data.repository.MatterTypeRepository;
@@ -123,6 +127,9 @@ class LookupServiceTest {
 
     @Mock
     private AssessmentSummaryAttributesRepository assessmentSummaryAttributesRepository;
+
+    @Mock
+    private DeclarationRepository declarationRepository;
 
     @Mock
     private LookupMapper lookupMapper;
@@ -658,4 +665,27 @@ class LookupServiceTest {
         entity.setEntityDisplaySequence(String.valueOf(entityLevel));
         return entity;
     }
+
+    @Test
+    @DisplayName("getDeclarationLookupValues returns page of declaration values")
+    void getDeclarationLookupValues_returnsPageOfDeclarationValues() {
+        String declarationType = "type1";
+        String billType = "bill1";
+        Pageable pageable = Pageable.unpaged();
+
+        Declaration declaration = new Declaration();
+        declaration.setDeclarationType(declarationType);
+        declaration.setBillType(billType);
+
+        Page<Declaration> expectedPage = new PageImpl<>(Collections.singletonList(declaration));
+        DeclarationLookupDetail expectedResponse = new DeclarationLookupDetail();
+
+        when(declarationRepository.findAll(Example.of(declaration), pageable)).thenReturn(expectedPage);
+        when(lookupMapper.toDeclarationLookupDetail(expectedPage)).thenReturn(expectedResponse);
+
+        DeclarationLookupDetail actualResponse = lookupService.getDeclarationLookupValues(declarationType, billType, pageable);
+
+        assertEquals(expectedResponse, actualResponse);
+    }
+
 }


### PR DESCRIPTION
Required for CCLS-2182 - submission declaration screen

As a user, 
I want to sign a declaration before submitting my application, 
so that I can confirm my agreement and proceed with the submission.

This endpoint enables the retrieval of declaration text which is used for the declaration screen. 