### PR TITLE
Fixed issue regarding empty notification type filter when searching notifications

### DIFF
--- a/data-service/src/main/java/uk/gov/laa/ccms/data/repository/specification/NotificationSpecification.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/repository/specification/NotificationSpecification.java
@@ -92,7 +92,7 @@ public class NotificationSpecification {
       if (Boolean.FALSE.equals(includeClosed)) {
         predicates.add(criteriaBuilder.equal(root.get("isOpen"), "true"));
       }
-      if (Objects.nonNull(notificationType)) {
+      if (stringNotEmpty(notificationType)) {
         predicates.add(criteriaBuilder.equal(root.get("actionNotificationInd"), notificationType));
       }
       if (Objects.nonNull(dateFrom)) {


### PR DESCRIPTION
Fixes an issue where currently the `NotificationSpecification` is attempting to match against an empty string for notification type when an empty string is passed to the API.