### PR TITLE
Update dependabot, bump versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,8 @@ updates:
     registries: "*"
     groups:
       gradle-updates:
-        patterns:
-          - "!uk.gov.laa.ccms.*" # All external Gradle dependencies
+        exclude-patterns:
+          - "uk.gov.laa.ccms.*"
       internal-packages:
         patterns:
           - "uk.gov.laa.ccms.*" # All internal Gradle dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,30 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+registries:
+  spring-boot-common-github-packages:
+    type: maven-repository
+    url: https://maven.pkg.github.com/ministryofjustice/laa-ccms-spring-boot-common
+    username: PhilDigitalJustice
+    password: ${{ secrets.REPO_TOKEN }}
 updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    registries: "*"
     groups:
       gradle-updates:
         patterns:
-          - "**" # Matches all Gradle dependencies
+          - "!uk.gov.laa.ccms.*" # All external Gradle dependencies
+      internal-packages:
+        patterns:
+          - "uk.gov.laa.ccms.*" # All internal Gradle dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "**"

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -46,9 +46,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification -Pversion=${{ steps.capture_version.outputs.app_version }}
+        run: ./gradlew build -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest -Pversion=${{ steps.capture_version.outputs.app_version }}
@@ -63,6 +66,30 @@ jobs:
         with:
           name: data-api-jar
           path: data-service/build/libs/data-service-${{ steps.capture_version.outputs.app_version }}.jar
+
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: data-service/build/reports/checkstyle
+          retention-days: 14
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: data-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: data-service/build/reports/jacoco
+          retention-days: 14
 
   ecr:
     needs: [ build-test-publish, define-image-tag ]

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -42,27 +42,19 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build -Pversion=${{ steps.capture_version.outputs.app_version }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification -Pversion=${{ steps.capture_version.outputs.app_version }}
-
       - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest -Pversion=${{ steps.capture_version.outputs.app_version }}
+        run: ./gradlew integrationTest -Pversion=${{ steps.capture_version.outputs.app_version }}
 
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish -Pversion=${{ steps.capture_version.outputs.app_version }}
+        run: ./gradlew publish -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Integration Test
+      - name: Integration test
         run: ./gradlew integrationTest -Pversion=${{ steps.capture_version.outputs.app_version }}
 
       - name: Publish package

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -40,17 +40,16 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: assemble
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew assemble
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -69,6 +69,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
       SNYK_TEST_EXCLUDE: build,generated
+      SNYK_TARGET_REFERENCE: main
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -78,12 +79,12 @@ jobs:
         continue-on-error: true
         with:
           command: monitor
-          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE
+          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE
       - name: Generate sarif Snyk report
         uses: snyk/actions/gradle@0.4.0
         continue-on-error: true
         with:
-          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
+          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE --sarif-file-output=snyk-report.sarif
       - name: Fix undefined values
         run: |
           cat snyk-report.sarif | jq '

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -31,22 +31,16 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
-
       - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest
+        run: ./gradlew integrationTest
 
       - name: Set to github user
         run: |
@@ -54,9 +48,7 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
 
       - name: Update version
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: release -Prelease.useAutomaticVersion=true
+        run: ./gradlew release -Prelease.useAutomaticVersion=true
 
   vulnerability-report:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -35,9 +35,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest
@@ -49,6 +52,30 @@ jobs:
 
       - name: Update version
         run: ./gradlew release -Prelease.useAutomaticVersion=true
+
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: data-service/build/reports/checkstyle
+          retention-days: 14
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: data-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: data-service/build/reports/jacoco
+          retention-days: 14
 
   vulnerability-report:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Integration Test
+      - name: Integration test
         run: ./gradlew integrationTest
 
       - name: Set to github user

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -64,6 +64,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
       SNYK_TEST_EXCLUDE: build,generated
+      SNYK_TARGET_REFERENCE: main
 
     steps:
       - uses: actions/checkout@v3
@@ -80,7 +81,7 @@ jobs:
           export PATH="$HOME/.local/bin/:$PATH"
           npm install -g snyk-delta
       - name: Identify new vulnerabilities
-        run: ./snyk/snyk_delta_all_projects.sh --org=$SNYK_ORG --exclude=$SNYK_TEST_EXCLUDE
+        run: ./snyk/snyk_delta_all_projects.sh --org=$SNYK_ORG --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run code test

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -32,9 +32,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest
@@ -46,6 +49,30 @@ jobs:
         run: ./gradlew publish
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: data-service/build/reports/checkstyle
+          retention-days: 14
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: data-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: data-service/build/reports/jacoco
+          retention-days: 14
 
   vulnerability-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Integration Test
+      - name: Integration test
         run: ./gradlew integrationTest
 
       - name: Update snapshot version

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -28,32 +28,22 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
-
       - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest
+        run: ./gradlew integrationTest
 
       - name: Update snapshot version
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: updateSnapshotVersion
+        run: ./gradlew updateSnapshotVersion
 
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,61 @@ This API uses components from the [LAA CCMS Common Library](https://github.com/m
 
 - [laa-ccms-spring-boot-plugin](https://github.com/ministryofjustice/laa-ccms-spring-boot-common?tab=readme-ov-file#laa-ccms-spring-boot-gradle-plugin-for-java--spring-boot-projects)
 - [laa-ccms-spring-boot-starter-auth](https://github.com/ministryofjustice/laa-ccms-spring-boot-common/tree/main/laa-ccms-spring-boot-starters/laa-ccms-spring-boot-starter-auth)
+
+## Snyk code analysis (CI/CD)
+This project publishes vulnerability scans to the [LAA Snyk Dashboard (Google SSO)](https://app.snyk.io/org/legal-aid-agency).
+
+If you cannot see the LAA organisation when logged into the dashboard,
+please ask your lead developer/architect to have you added.
+
+Scans will be triggered in two ways:
+
+- Main branch - on commit, a vulnerability scan will be run and published to both the Snyk
+  server and GitHub Code Scanning. Vulnerabilites will not fail the build.
+- Feature branches - on commit, a vulnerability scan will be run to identify any new
+  vulnerabilites (compared to the main branch). If new vulnerabilites have been raised. A code
+  scan will also run to identify known security issues within the source code. If any issues are
+  found, the build will fail.
+
+### Running Snyk locally
+To run Snyk locally, you will need to [install the Snyk CLI](https://docs.snyk.io/snyk-cli/install-or-update-the-snyk-cli).
+
+Once installed, you will be able to run the following commands:
+
+```shell
+snyk test
+```
+For open-source vulnerabilies and licence issues. See [`snyk test`](https://docs.snyk.io/snyk-cli/commands/test).
+
+```shell
+snyk code test
+```
+For Static Application Security Testing (SAST) - known security issues. See [`snyk code test`](https://docs.snyk.io/snyk-cli/commands/code-test).
+
+A [JetBrains Plugin](https://plugins.jetbrains.com/plugin/10972-snyk-security) is also available to integrate with your IDE. In addition to
+vulnerabilities, this plugin will also report code quality issues.
+
+### Configuration (`.snyk`)
+
+The [.snyk](.snyk) file is used to configure exclusions for scanning. If a vulnerability is not
+deemed to be a threat, or will be dealt with later, it can be added here to stop the pipeline
+failing. See [documentation](https://docs.snyk.io/manage-risk/policies/the-.snyk-file) for more details.
+
+### False Positives
+
+Snyk may report that new vulnerabilities have been introduced on a feature branch and fail the
+pipeline, even if this is not the case. As newly identified vulnerabilities are always being
+published, the report for the main branch may become outdated when a new vulnerability is published.
+
+If you think this may be the case, simply re-run the `monitor` command against the `main` branch
+to update the report on the Snyk server, then re-run your pipeline.
+
+Please ensure this matches the command used by the [pr-merge-main](.github/workflows/pr-merge-main.yml)
+workflow to maintain consistency.
+
+```shell
+snyk monitor --org=legal-aid-agency --all-projects --exclude=build,generated --target-reference=main
+```
+
+You should then see the new vulnerability in the LAA Dashboard, otherwise it is a new
+vulnerability introduced on the feature branch that needs to be resolved.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.0.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.24' apply false
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.25' apply false
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.0.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.17' apply false
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.24' apply false
 }
 
 subprojects {

--- a/data-service/build.gradle
+++ b/data-service/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
 
     //Used for integration tests
-    implementation platform('org.testcontainers:testcontainers-bom:1.20.4')
+    testImplementation platform('org.testcontainers:testcontainers-bom:1.20.4')
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:oracle-free'

--- a/data-service/build.gradle
+++ b/data-service/build.gradle
@@ -40,6 +40,8 @@ test {
 
     // Hide warning for dynamic loading of agents https://github.com/mockito/mockito/issues/3037
     jvmArgs '-XX:+EnableDynamicAgentLoading'
+
+    finalizedBy jacocoTestReport
 }
 
 jacocoTestReport {


### PR DESCRIPTION
* Dependabot
  * Scan for github-actions updates
  * Scan for SB common library updates
* Snyk
  * Consolidate reporting - duplicate reports are created when running `monitor` from local cli vs in the pipeline. Adding `--target-reference=main` to all commands should make them point to one report. 
* Bump to latest SB common library version
  * Fixed bug where duplicate unit tests would run twice in pipelines (`build` would run tests, followed by `jacocoTestVerification`)
* Workflows
  * Replace deprecated `gradle-build-action` with `setup-gradle` action
  * Upload checkstyle, test and jacoco coverage artifacts
  * Fixed bug where test coverage verification would run without jacoco report (effectively always passing)