### PR TITLE
Added case reference number check to getCaseDetails in CaseService.

### DIFF
--- a/data-service/src/main/java/uk/gov/laa/ccms/data/exception/EbsApiRuntimeException.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/exception/EbsApiRuntimeException.java
@@ -1,0 +1,24 @@
+package uk.gov.laa.ccms.data.exception;
+
+public class EbsApiRuntimeException extends RuntimeException {
+
+  public EbsApiRuntimeException() {
+  }
+
+  public EbsApiRuntimeException(String message) {
+    super(message);
+  }
+
+  public EbsApiRuntimeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public EbsApiRuntimeException(Throwable cause) {
+    super(cause);
+  }
+
+  public EbsApiRuntimeException(String message, Throwable cause, boolean enableSuppression,
+      boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/exception/EbsApiRuntimeException.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/exception/EbsApiRuntimeException.java
@@ -1,5 +1,11 @@
 package uk.gov.laa.ccms.data.exception;
 
+/**
+ * Represents a custom runtime exception used for handling errors in the EBS API.
+ * This class extends {@link RuntimeException}.
+ *
+ * @author Jamie Briggs
+ */
 public class EbsApiRuntimeException extends RuntimeException {
 
   public EbsApiRuntimeException() {

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/mapper/casedetails/xml/casedetail/CaseDetailXml.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/mapper/casedetails/xml/casedetail/CaseDetailXml.java
@@ -1,12 +1,14 @@
 package uk.gov.laa.ccms.data.mapper.casedetails.xml.casedetail;
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import uk.gov.laa.ccms.data.mapper.casedetails.xml.CaseDetailXmlNamespaces;
+import uk.gov.laa.ccms.data.mapper.casedetails.xml.common.MessageXml;
 
 /**
  * Case detail object, which contains both the case reference number, and an object containing
@@ -15,20 +17,20 @@ import uk.gov.laa.ccms.data.mapper.casedetails.xml.CaseDetailXmlNamespaces;
  * @see CaseDetailsXml
  * @author Jamie Briggs
  */
-@Getter
-@Setter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public final class CaseDetailXml {
+@JacksonXmlRootElement(localName = "Case")
+public record CaseDetailXml(
+    @JacksonXmlProperty(localName = "CaseReferenceNumber",
+        namespace = CaseDetailXmlNamespaces.CASE_NAMESPACE)
+    String caseReferenceNumber,
 
-  @JacksonXmlProperty(localName = "CaseReferenceNumber",
-      namespace = CaseDetailXmlNamespaces.CASE_NAMESPACE)
-  private String caseReferenceNumber;
+    @JacksonXmlProperty(localName = "CaseDetails",
+        namespace = CaseDetailXmlNamespaces.CASE_NAMESPACE)
+    CaseDetailsXml caseDetails,
 
-  @JacksonXmlProperty(localName = "CaseDetails",
-      namespace = CaseDetailXmlNamespaces.CASE_NAMESPACE)
-  private CaseDetailsXml caseDetails;
+    @JacksonXmlProperty(localName = "Message",
+        namespace = CaseDetailXmlNamespaces.CASE_NAMESPACE)
+    MessageXml message) {
 
 
 }

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/mapper/casedetails/xml/common/MessageXml.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/mapper/casedetails/xml/common/MessageXml.java
@@ -1,0 +1,18 @@
+package uk.gov.laa.ccms.data.mapper.casedetails.xml.common;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * Message object, which contains fields to capture the status of a case returned from EBS.
+ *
+ * @param code The code returned from EBS (200, 404, 500).
+ * @param status The status of the case.
+ * @param text Description of the message.
+ */
+public record MessageXml(
+    @JacksonXmlProperty(localName = "Code")
+    String code,
+    @JacksonXmlProperty(localName = "Status")
+    String status,
+    @JacksonXmlProperty(localName = "Text")
+    String text) { }

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/repository/CaseDetailRepository.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/repository/CaseDetailRepository.java
@@ -66,16 +66,10 @@ public class CaseDetailRepository {
    *     SQL function invocation
    */
   public CaseInqRsXml getCaseDetailXml(String caseReference, Long providerId,
-      String userName) throws SQLException {
+      String userName) throws SQLException, JsonProcessingException {
     String caseDetailViaFunction = getCaseDetailViaFunction(caseReference, providerId,
         userName);
-    try {
-      return this.xmlMapper.readValue(caseDetailViaFunction, CaseInqRsXml.class);
-    } catch (JsonProcessingException e) {
-      // Due to how the EBS function works, if the case can't be found, XML is still returned but
-      //  in a bad format. Just return null if this is the case.
-      return null;
-    }
+    return this.xmlMapper.readValue(caseDetailViaFunction, CaseInqRsXml.class);
   }
 
   private String getCaseDetailViaFunction(String caseReference, Long providerId,

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/service/CaseService.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/service/CaseService.java
@@ -93,7 +93,8 @@ public class CaseService {
       throws SQLException {
     CaseInqRsXml caseXml = caseDetailRepository.getCaseDetailXml(caseReferenceNumber, providerId,
         userName);
-    if (caseXml != null && caseXml.getCaseDetail() != null) {
+    if (caseXml != null && caseXml.getCaseDetail() != null
+        && caseXml.getCaseDetail().getCaseReferenceNumber() != null) {
       CaseDetail caseDetail = caseDetailsMapper.mapToCaseDetail(caseXml.getCaseDetail());
       return Optional.of(caseDetail);
     }

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/service/CaseService.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/service/CaseService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.laa.ccms.data.mapper.TransactionStatusMapper;
 import uk.gov.laa.ccms.data.mapper.casedetails.CaseDetailsMapper;
 import uk.gov.laa.ccms.data.mapper.casedetails.xml.casedetail.CaseInqRsXml;
+import uk.gov.laa.ccms.data.mapper.casedetails.xml.common.MessageXml;
 import uk.gov.laa.ccms.data.model.CaseDetail;
 import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.repository.CaseDetailRepository;
@@ -17,12 +18,12 @@ import uk.gov.laa.ccms.data.repository.TransactionStatusRepository;
  * Service class responsible for handling case-related operations.
  *
  * <p>This class provides methods to retrieve transaction statuses for case-related
- * transactions. It utilizes a repository for database access and a mapper for converting
- * database entities to objects used in the application.</p>
+ * transactions. It utilizes a repository for database access and a mapper for converting database
+ * entities to objects used in the application.</p>
  *
+ * @author Jamie Briggs
  * @see TransactionStatusRepository
  * @see TransactionStatusMapper
- * @author Jamie Briggs
  */
 @Service
 public class CaseService {
@@ -35,11 +36,11 @@ public class CaseService {
   /**
    * Constructs an instance of {@code CaseService}.
    *
-   * @param caseDetailRepository the repository used for accessing case details
-   * @param caseDetailsMapper the mapper used for mapping case detail entities to models
+   * @param caseDetailRepository        the repository used for accessing case details
+   * @param caseDetailsMapper           the mapper used for mapping case detail entities to models
    * @param transactionStatusRepository the repository used for accessing transaction statuses
-   * @param transactionStatusMapper the mapper used for mapping transaction status entities
-   *                                to models
+   * @param transactionStatusMapper     the mapper used for mapping transaction status entities to
+   *                                    models
    */
   public CaseService(CaseDetailRepository caseDetailRepository, CaseDetailsMapper caseDetailsMapper,
       TransactionStatusRepository transactionStatusRepository,
@@ -51,18 +52,15 @@ public class CaseService {
   }
 
 
-
-
   /**
-   * Retrieves the transaction status for a given transaction ID. If the transaction
-   *     is not found, an empty {@code Optional} is returned.
+   * Retrieves the transaction status for a given transaction ID. If the transaction is not found,
+   * an empty {@code Optional} is returned.
    *
-   * @param transactionId the unique identifier of the transaction whose status
-   *     is to be retrieved
-   * @return an {@code Optional} containing the {@link TransactionStatus} if found,
-   *     or an empty {@code Optional} if not found
-   * @throws ClientServiceException throws exception when there was an error found
-   *     with the associated transaction ID
+   * @param transactionId the unique identifier of the transaction whose status is to be retrieved
+   * @return an {@code Optional} containing the {@link TransactionStatus} if found, or an empty
+   *     {@code Optional} if not found
+   * @throws ClientServiceException throws exception when there was an error found with the
+   *                                associated transaction ID
    */
   public Optional<TransactionStatus> getTransactionStatus(String transactionId) {
     List<uk.gov.laa.ccms.data.entity.TransactionStatus> userFuncStatus =
@@ -76,28 +74,35 @@ public class CaseService {
   }
 
   /**
-   * Retrieves the details of a case based on the provided case reference number, provider ID,
-   * and the username of the user fetching this case.
+   * Retrieves the details of a case based on the provided case reference number, provider ID, and
+   * the username of the user fetching this case.
    *
    * @param caseReferenceNumber the unique reference number of the case
-   * @param providerId the ID of the provider associated with the case
-   * @param userName the username of the user accessing this case. Dictates what available
-   *                     functions are returned alongside the case.
-   * @return an {@code Optional} containing the {@link CaseDetail} if the case details are found,
-   *         or an empty {@code Optional} if no details are available
-   * @throws JsonProcessingException if there is an error processing XML data related to the case
-   * @throws SQLException if an error occurs while interacting with the database
+   * @param providerId          the ID of the provider associated with the case
+   * @param userName            the username of the user accessing this case. Dictates what
+   *                            available functions are returned alongside the case.
+   * @return an {@code Optional} containing the {@link CaseDetail} if the case details are found, or
+   *     an empty {@code Optional} if no details are available
+   * @throws SQLException            if an error occurs while interacting with the database
    */
   public Optional<CaseDetail> getCaseDetails(String caseReferenceNumber, Long providerId,
       String userName)
       throws SQLException {
     CaseInqRsXml caseXml = caseDetailRepository.getCaseDetailXml(caseReferenceNumber, providerId,
         userName);
-    if (caseXml != null && caseXml.getCaseDetail() != null
-        && caseXml.getCaseDetail().getCaseReferenceNumber() != null) {
-      CaseDetail caseDetail = caseDetailsMapper.mapToCaseDetail(caseXml.getCaseDetail());
-      return Optional.of(caseDetail);
+    if (caseXml != null && caseXml.getCaseDetail() != null) {
+      // Check status codes
+      MessageXml messageXml = caseXml.getCaseDetail().message();
+      if ("200".equals(messageXml.code())) {
+        CaseDetail caseDetail = caseDetailsMapper.mapToCaseDetail(caseXml.getCaseDetail());
+        return Optional.of(caseDetail);
+      } else if ("404".equals(messageXml.code())) {
+        return Optional.empty();
+      } else {
+        throw new SQLException("Error occurred in EBS: %s - %s".formatted(messageXml.code(),
+            messageXml.text()));
+      }
     }
-    return Optional.empty();
+    throw new RuntimeException("Could not retrieve case details from EBS");
   }
 }

--- a/data-service/src/main/java/uk/gov/laa/ccms/data/service/CaseService.java
+++ b/data-service/src/main/java/uk/gov/laa/ccms/data/service/CaseService.java
@@ -3,6 +3,7 @@ package uk.gov.laa.ccms.data.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 import uk.gov.laa.ccms.data.exception.EbsApiRuntimeException;
@@ -59,7 +60,7 @@ public class CaseService {
    *
    * @param transactionId the unique identifier of the transaction whose status is to be retrieved
    * @return an {@code Optional} containing the {@link TransactionStatus} if found, or an empty
-   * {@code Optional} if not found
+   *     {@code Optional} if not found
    * @throws ClientServiceException throws exception when there was an error found with the
    *                                associated transaction ID
    */
@@ -83,7 +84,7 @@ public class CaseService {
    * @param userName            the username of the user accessing this case. Dictates what
    *                            available functions are returned alongside the case.
    * @return an {@code Optional} containing the {@link CaseDetail} if the case details are found, or
-   * an empty {@code Optional} if no details are available
+   *     an empty {@code Optional} if no details are available
    */
   public Optional<CaseDetail> getCaseDetails(String caseReferenceNumber, Long providerId,
       String userName) {
@@ -98,9 +99,9 @@ public class CaseService {
   }
 
   private void validateCaseXmlObject(CaseInqRsXml caseInqRsXml) {
-    if (caseInqRsXml == null ||
-        caseInqRsXml.getCaseDetail() == null ||
-        caseInqRsXml.getCaseDetail().message() == null) {
+    if (Objects.isNull(caseInqRsXml)
+        || Objects.isNull(caseInqRsXml.getCaseDetail())
+        || Objects.isNull(caseInqRsXml.getCaseDetail().message())) {
       throw new EbsApiRuntimeException("Could not retrieve case details from EBS");
     }
   }

--- a/data-service/src/test/java/uk/gov/laa/ccms/data/service/CaseServiceTest.java
+++ b/data-service/src/test/java/uk/gov/laa/ccms/data/service/CaseServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.laa.ccms.data.service;
 
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,15 +9,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.sql.SQLException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.laa.ccms.data.mapper.casedetails.CaseDetailsMapper;
 import uk.gov.laa.ccms.data.mapper.TransactionStatusMapper;
+import uk.gov.laa.ccms.data.mapper.casedetails.xml.casedetail.CaseDetailXml;
+import uk.gov.laa.ccms.data.mapper.casedetails.xml.casedetail.CaseInqRsXml;
+import uk.gov.laa.ccms.data.mapper.casedetails.xml.common.MessageXml;
+import uk.gov.laa.ccms.data.model.CaseDetail;
 import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.repository.CaseDetailRepository;
 import uk.gov.laa.ccms.data.repository.TransactionStatusRepository;
@@ -134,5 +141,82 @@ public class CaseServiceTest {
         transactionId);
     verify(transactionStatusRepository, times(0)).findCaseApplicationTransactionByTransactionId(
         transactionId);
+  }
+
+  @Nested
+  @DisplayName("GetCaseDetails() Tests")
+  class GetCaseDetailsTests {
+
+    @Test
+    @DisplayName("Should return case details")
+    void shouldReturnCaseDetails() throws SQLException {
+      // Given
+      CaseInqRsXml caseInqRsXml = CaseInqRsXml.builder()
+          .caseDetail(CaseDetailXml.builder()
+              .message(new MessageXml("200", "status", "text"))
+              .build()).build();
+      CaseDetail caseDetail = new CaseDetail();
+      caseDetail.setCaseReferenceNumber("123");
+      when(caseDetailRepository.getCaseDetailXml("123", 1L, "user"))
+          .thenReturn(caseInqRsXml);
+      when(caseDetailsMapper.mapToCaseDetail(caseInqRsXml.getCaseDetail()))
+          .thenReturn(caseDetail);
+      // When
+      Optional<CaseDetail> result = caseService.getCaseDetails("123",
+          1L, "user");
+      // Then
+      assertThat(result).isPresent();
+      assertThat(result.get().getCaseReferenceNumber()).isEqualTo("123");
+    }
+
+    @Test
+    @DisplayName("Should return empty optional")
+    void shouldReturnEmptyOptional() throws SQLException {
+      // Given
+      CaseInqRsXml caseInqRsXml = CaseInqRsXml.builder()
+          .caseDetail(CaseDetailXml.builder()
+              .message(new MessageXml("404", "status", "not found"))
+              .build()).build();
+      when(caseDetailRepository.getCaseDetailXml("123", 1L, "user"))
+          .thenReturn(caseInqRsXml);
+      // When
+      Optional<CaseDetail> result = caseService.getCaseDetails("123",
+          1L, "user");
+      // Then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should throw exception when message contains error")
+    void shouldThrowExceptionWhenMessageContainsError() throws SQLException {
+      // Given
+      CaseInqRsXml caseInqRsXml = CaseInqRsXml.builder()
+          .caseDetail(CaseDetailXml.builder()
+            .message(new MessageXml("ORA-12345", "status", "SQL Error"))
+              .build()).build();
+      when(caseDetailRepository.getCaseDetailXml("123", 1L, "user"))
+          .thenReturn(caseInqRsXml);
+      // When
+      SQLException result = assertThrows(SQLException.class,
+          () -> caseService.getCaseDetails("123",
+          1L, "user"));
+      // Then
+      assertThat(result.getMessage())
+          .isEqualTo("Error occurred in EBS: ORA-12345 - SQL Error");
+    }
+
+    @Test
+    @DisplayName("Should throw runtime exception when no case")
+    void shouldThrowRuntimeExceptionWhenNoCase() throws SQLException {
+      // Given
+      // When
+      RuntimeException result = assertThrows(RuntimeException.class,
+          () -> caseService.getCaseDetails("123",
+              1L, "user"));
+      // Then
+      assertThat(result.getMessage())
+          .isEqualTo("Could not retrieve case details from EBS");
+    }
+
   }
 }

--- a/data-service/src/test/java/uk/gov/laa/ccms/data/service/CaseServiceTest.java
+++ b/data-service/src/test/java/uk/gov/laa/ccms/data/service/CaseServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.sql.SQLException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.laa.ccms.data.exception.EbsApiRuntimeException;
 import uk.gov.laa.ccms.data.mapper.casedetails.CaseDetailsMapper;
 import uk.gov.laa.ccms.data.mapper.TransactionStatusMapper;
 import uk.gov.laa.ccms.data.mapper.casedetails.xml.casedetail.CaseDetailXml;
@@ -149,7 +151,7 @@ public class CaseServiceTest {
 
     @Test
     @DisplayName("Should return case details")
-    void shouldReturnCaseDetails() throws SQLException {
+    void shouldReturnCaseDetails() throws SQLException, JsonProcessingException {
       // Given
       CaseInqRsXml caseInqRsXml = CaseInqRsXml.builder()
           .caseDetail(CaseDetailXml.builder()
@@ -171,7 +173,7 @@ public class CaseServiceTest {
 
     @Test
     @DisplayName("Should return empty optional")
-    void shouldReturnEmptyOptional() throws SQLException {
+    void shouldReturnEmptyOptional() throws SQLException, JsonProcessingException {
       // Given
       CaseInqRsXml caseInqRsXml = CaseInqRsXml.builder()
           .caseDetail(CaseDetailXml.builder()
@@ -188,7 +190,7 @@ public class CaseServiceTest {
 
     @Test
     @DisplayName("Should throw exception when message contains error")
-    void shouldThrowExceptionWhenMessageContainsError() throws SQLException {
+    void shouldThrowExceptionWhenMessageContainsError() throws SQLException, JsonProcessingException {
       // Given
       CaseInqRsXml caseInqRsXml = CaseInqRsXml.builder()
           .caseDetail(CaseDetailXml.builder()
@@ -197,7 +199,7 @@ public class CaseServiceTest {
       when(caseDetailRepository.getCaseDetailXml("123", 1L, "user"))
           .thenReturn(caseInqRsXml);
       // When
-      SQLException result = assertThrows(SQLException.class,
+      EbsApiRuntimeException result = assertThrows(EbsApiRuntimeException.class,
           () -> caseService.getCaseDetails("123",
           1L, "user"));
       // Then


### PR DESCRIPTION
When a case doesn't exist in EBS, caseDetailRepository returns an empty case. With the original logic, this meant that even if the case didn't exist, it would still try to map and return an object when really it just return an empty optional. This fixes this issue.